### PR TITLE
Fix non-deterministic tests in JSONCoderTest.java

### DIFF
--- a/JSONCoder/pom.xml
+++ b/JSONCoder/pom.xml
@@ -30,5 +30,10 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/SnapshotTest/src/main/java/org/jsonex/snapshottest/Snapshot.java
+++ b/SnapshotTest/src/main/java/org/jsonex/snapshottest/Snapshot.java
@@ -77,7 +77,7 @@ public class Snapshot {
         tempFile.delete();
         result = Result.MATCHES;
         message = null;
-        return this; 
+        return this;
       } catch (Exception e) {
         message = this + " and actual mismatch. The actual is record in file:\nfile://" + tempFile.getAbsolutePath() +
             "\nPlease review the difference. If the change is expected, please override the snapshot file with the tmp file.";

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
         <version>2.8.5</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.skyscreamer</groupId>
+        <artifactId>jsonassert</artifactId>
+        <version>1.5.0</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
Hi,

The tests in JSONCoderTest.java are non-deterministic because when comparing JSON strings, the tests do not account for different order of fields in the JSON string. This problem is caused by comparing JSON strings using normal string comparison using `Objects.equals(actualString, expected)` here - https://github.com/eBay/jsonex/blob/master/SnapshotTest/src/main/java/org/jsonex/snapshottest/Snapshot.java#L69. The order of JSON fields in a JSON string is not guaranteed, so the string comparison can non-deterministically fail. 

The solution is to do a JSON to JSON comparison on JSON strings. Such a comparison converts the JSON strings to JSON objects and then compares those two objects. One way to do that is to use this nice library called JSONAssert (https://github.com/skyscreamer/JSONassert), which is what I have done in this PR. If there is another elegant way to solve this problem, I can implement that as well.

Please let me know if you have any questions.